### PR TITLE
Fix cast: :atom can cause a memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ end
 
 # /posts
 # => #Ecto.Query<from p in Post, order_by: [desc: p.inserted_at]>
-@options param: [:sort, :order], default: [sort: :inserted_at, order: :desc], cast: :atom
+@options param: [:sort, :order], default: [sort: :inserted_at, order: :desc], cast: :atom_unchecked
 filter search(query, %{sort: field, order: order}, _conn) do
   query |> order_by([{^order, ^field}])
 end
@@ -237,7 +237,9 @@ filter title(query, value, _conn) do
 end
 ```
 
-`:cast` - allows to convert value to specific type. Available types are: `integer`, `float`, `string`, `atom`, `boolean`, `date`, `datetime`. Also can accept pointer to function:
+`:cast` - allows to convert value to specific type. Available types are: `:integer`, `:float`, `:string`, `{:atom, [...]}`, `:boolean`, `:date`, `:datetime`, `:atom_unchecked`.  Casting to atoms is a special case, as atoms are never garbage collected.  It is therefore important to give a list of valid atoms.  Casting will only work if the given value is in the list of atoms.
+
+Also can accept pointer to function:
 
 ```elixir
 # /posts?limit=20

--- a/lib/filterable.ex
+++ b/lib/filterable.ex
@@ -105,7 +105,8 @@ defmodule Filterable do
   end
 
   defp filters_result(queryable, filter_values, module, opts) do
-    Utils.reduce_with(module.defined_filters, queryable, fn {filter_name, filter_opts}, queryable ->
+    Utils.reduce_with(module.defined_filters, queryable, fn {filter_name, filter_opts},
+                                                            queryable ->
       options = Keyword.merge(opts, filter_opts)
       value = Map.get(filter_values, filter_name)
 

--- a/lib/filterable.ex
+++ b/lib/filterable.ex
@@ -105,8 +105,7 @@ defmodule Filterable do
   end
 
   defp filters_result(queryable, filter_values, module, opts) do
-    Utils.reduce_with(module.defined_filters, queryable, fn {filter_name, filter_opts},
-                                                            queryable ->
+    Utils.reduce_with(module.defined_filters, queryable, fn {filter_name, filter_opts}, queryable ->
       options = Keyword.merge(opts, filter_opts)
       value = Map.get(filter_values, filter_name)
 

--- a/lib/filterable/cast.ex
+++ b/lib/filterable/cast.ex
@@ -70,16 +70,35 @@ defmodule Filterable.Cast do
     to_string(value)
   end
 
-  @spec atom(String.t() | atom) :: atom | :error
-  def atom(value) when is_bitstring(value) do
+  @spec atom(String.t() | atom, List.t(atom)) :: atom | :error
+  def atom(value, checked_values) when is_binary(value) do
+    case Enum.find(checked_values, &(Atom.to_string(&1) == value)) do
+      nil -> :error
+      value -> value
+    end
+  end
+
+  def atom(value, checked_values) when is_atom(value) do
+    case Enum.find(checked_values, &(&1 == value)) do
+      nil -> :error
+      _ -> value
+    end
+  end
+
+  def atom(_, _) do
+    :error
+  end
+
+  @spec atom_unchecked(String.t() | atom) :: atom | :error
+  def atom_unchecked(value) when is_binary(value) do
     String.to_atom(value)
   end
 
-  def atom(value) when is_atom(value) do
+  def atom_unchecked(value) when is_atom(value) do
     value
   end
 
-  def atom(_) do
+  def atom_unchecked(_) do
     :error
   end
 

--- a/lib/filterable/dsl.ex
+++ b/lib/filterable/dsl.ex
@@ -53,6 +53,12 @@ defmodule Filterable.DSL do
       @filters Keyword.put_new(@filters, unquote(filter_name), options || [])
       Module.delete_attribute(__MODULE__, :options)
 
+      if options != nil && Enum.member?(options, {:cast, :atom}) do
+        IO.warn "`cast: :atom` is deprecated for filter '#{to_string(unquote(filter_name))}'.
+          Consider using `cast: {:atom, [:foo, :bar]}` to check for valid atoms before casting.
+          To cast into an atom without validating the value, use `cast: :atom_unchecked`."
+      end
+
       def unquote(head), do: unquote(body)
     end
   end

--- a/lib/filterable/dsl.ex
+++ b/lib/filterable/dsl.ex
@@ -54,9 +54,9 @@ defmodule Filterable.DSL do
       Module.delete_attribute(__MODULE__, :options)
 
       if options != nil && Enum.member?(options, {:cast, :atom}) do
-        IO.warn "`cast: :atom` is deprecated for filter '#{to_string(unquote(filter_name))}'.
+        IO.warn("`cast: :atom` is deprecated for filter '#{to_string(unquote(filter_name))}'.
           Consider using `cast: {:atom, [:foo, :bar]}` to check for valid atoms before casting.
-          To cast into an atom without validating the value, use `cast: :atom_unchecked`."
+          To cast into an atom without validating the value, use `cast: :atom_unchecked`.")
       end
 
       def unquote(head), do: unquote(body)

--- a/lib/filterable/ecto/helpers.ex
+++ b/lib/filterable/ecto/helpers.ex
@@ -60,8 +60,10 @@ defmodule Filterable.Ecto.Helpers do
   end
 
   defmacro orderable(fields) when is_list(fields) do
+    fields = Enum.map(fields, &to_string/1)
+
     quote do
-      @options param: [:sort, :order], default: [order: :desc], cast: :atom, share: false
+      @options param: [:sort, :order], default: [order: "desc"], cast: :string, share: false
       filter sort(query, %{sort: nil, order: _}) do
         query
       end
@@ -70,11 +72,13 @@ defmodule Filterable.Ecto.Helpers do
         {:error, "Unable to sort on #{inspect(field)}, only name and surname allowed"}
       end
 
-      filter sort(_, %{sort: _, order: order}) when not (order in ~w(asc desc)a) do
+      filter sort(_, %{sort: _, order: order}) when not (order in ~w(asc desc)) do
         {:error, "Unable to sort using #{inspect(order)}, only 'asc' and 'desc' allowed"}
       end
 
       filter sort(query, %{sort: field, order: order}) do
+        field = String.to_atom(field)
+        order = String.to_atom(order)
         query |> Ecto.Query.order_by([{^order, ^field}])
       end
     end

--- a/lib/filterable/params.ex
+++ b/lib/filterable/params.ex
@@ -200,6 +200,14 @@ defmodule Filterable.Params do
     nil
   end
 
+  defp cast(value, :atom) do
+    cast(value, :atom_unchecked)
+  end
+
+  defp cast(value, {:atom, checked_values}) do
+    Filterable.Cast.atom(value, checked_values)
+  end
+
   defp cast(value, cast) when is_atom(cast) do
     apply(Filterable.Cast, cast, [value])
   end

--- a/test/filterable/cast_test.exs
+++ b/test/filterable/cast_test.exs
@@ -57,17 +57,39 @@ defmodule Filterable.CastTest do
     end
   end
 
-  describe "atom/1" do
-    test "returns casted value" do
-      assert Cast.atom("string") == :string
+  describe "atom/2" do
+    test "returns the casted string if present in the allowed values" do
+      assert Cast.atom("foo", [:foo, :bar]) == :foo
     end
 
-    test "returns original value" do
-      assert Cast.atom(:atom) == :atom
+    test "returns :error if the string is not present in the allowed values" do
+      assert Cast.atom("toto", [:foo, :bar]) == :error
+    end
+
+    test "returns the given atom if it is present in the allowed values" do
+      assert Cast.atom(:foo, [:foo, :bar]) == :foo
+    end
+
+    test "returns :error if the given atom is not present in the allowed values" do
+      assert Cast.atom(:toto, [:foo, :bar]) == :error
     end
 
     test "returns :error if unable to cast" do
-      assert Cast.atom(123) == :error
+      assert Cast.atom(123, [:foo, :bar]) == :error
+    end
+  end
+
+  describe "atom_unchecked/1" do
+    test "returns casted value" do
+      assert Cast.atom_unchecked("string") == :string
+    end
+
+    test "returns original value" do
+      assert Cast.atom_unchecked(:atom_unchecked) == :atom_unchecked
+    end
+
+    test "returns :error if unable to cast" do
+      assert Cast.atom_unchecked(123) == :error
     end
   end
 

--- a/test/filterable/params_test.exs
+++ b/test/filterable/params_test.exs
@@ -223,6 +223,16 @@ defmodule Filterable.ParamsTest do
       assert value == []
     end
 
+    test "to atom" do
+      {:ok, value} = filter_value(@params, param: :human, cast: {:atom, [:true, :false]})
+      assert value == :false
+    end
+
+    test "to atom unchecked" do
+      {:ok, value} = filter_value(@params, param: :name, cast: :atom_unchecked)
+      assert value == :"Tom"
+    end
+
     test "using wrong cast param" do
       {:ok, value} = filter_value(@params, param: :keywords, trim: true, cast: %{})
       assert value == %{one: 1, two: nil}

--- a/test/filterable/params_test.exs
+++ b/test/filterable/params_test.exs
@@ -224,13 +224,13 @@ defmodule Filterable.ParamsTest do
     end
 
     test "to atom" do
-      {:ok, value} = filter_value(@params, param: :human, cast: {:atom, [:true, :false]})
-      assert value == :false
+      {:ok, value} = filter_value(@params, param: :human, cast: {:atom, [true, false]})
+      assert value == false
     end
 
     test "to atom unchecked" do
       {:ok, value} = filter_value(@params, param: :name, cast: :atom_unchecked)
-      assert value == :"Tom"
+      assert value == :Tom
     end
 
     test "using wrong cast param" do

--- a/test/filterable/params_test.exs
+++ b/test/filterable/params_test.exs
@@ -228,6 +228,11 @@ defmodule Filterable.ParamsTest do
       assert value == false
     end
 
+    test "to atom deprecated" do
+      {:ok, value} = filter_value(@params, param: :human, cast: :atom)
+      assert value == false
+    end
+
     test "to atom unchecked" do
       {:ok, value} = filter_value(@params, param: :name, cast: :atom_unchecked)
       assert value == :Tom

--- a/test/filterable/phoenix/controller_test.exs
+++ b/test/filterable/phoenix/controller_test.exs
@@ -29,7 +29,7 @@ defmodule Filterable.Phoenix.ControllerTest do
              name: "Martin",
              age: 22,
              paginate: %{page: 1, per_page: 4},
-             sort: %{order: :desc, sort: nil}
+             sort: %{order: "desc", sort: nil}
            }
 
     params = Plug.Conn.Query.decode("name=    &age=190")
@@ -42,7 +42,7 @@ defmodule Filterable.Phoenix.ControllerTest do
     assert values == %{
              age: 190,
              paginate: %{page: 1, per_page: 4},
-             sort: %{order: :desc, sort: nil}
+             sort: %{order: "desc", sort: nil}
            }
   end
 

--- a/test/filterable/phoenix/model_test.exs
+++ b/test/filterable/phoenix/model_test.exs
@@ -15,7 +15,7 @@ defmodule Filterable.Phoenix.ModelTest do
              name: "Martin",
              age: 22,
              paginate: %{page: 1, per_page: 4},
-             sort: %{order: :desc, sort: nil}
+             sort: %{order: "desc", sort: nil}
            }
 
     params = Plug.Conn.Query.decode("name=    &age=190")
@@ -28,7 +28,7 @@ defmodule Filterable.Phoenix.ModelTest do
     assert values == %{
              age: 190,
              paginate: %{page: 1, per_page: 4},
-             sort: %{order: :desc, sort: nil}
+             sort: %{order: "desc", sort: nil}
            }
   end
 

--- a/test/filterable_test.exs
+++ b/test/filterable_test.exs
@@ -61,12 +61,12 @@ defmodule FilterableTest do
 
     test "returns error if sort direction invalid" do
       {:error, message} = apply_filters(User, %{sort: :name, order: :test})
-      assert message == "Unable to sort using :test, only 'asc' and 'desc' allowed"
+      assert message == "Unable to sort using \"test\", only 'asc' and 'desc' allowed"
     end
 
     test "raises error if sort field invalid" do
       {:error, message} = apply_filters(User, %{sort: :test, order: :desc})
-      assert message == "Unable to sort on :test, only name and surname allowed"
+      assert message == "Unable to sort on \"test\", only name and surname allowed"
     end
   end
 


### PR DESCRIPTION
`cast: :atom` is now deprecated in favor of `cast: {:atom, [:foo, :bar]}`.

If the old behaviour is required, `cast: :atom_unchecked` can be used.

Fixes: https://github.com/omohokcoj/filterable/issues/8